### PR TITLE
fidelityAPI stability improvements

### DIFF
--- a/fidelityAPI.py
+++ b/fidelityAPI.py
@@ -80,30 +80,6 @@ async def fidelity_holdings(driver, ctx):
     print("Fidelity Holdings")
     print("==============================")
     print()
-    
-    # relogin if fidelity has logged out
-    try:
-        WebDriverWait(driver, 5).until(
-            expected_conditions.presence_of_element_located((By.CSS_SELECTOR, "#userId-input"))
-                                        )
-        FIDELITY_USERNAME = os.environ["FIDELITY_USERNAME"]
-        FIDELITY_PASSWORD = os.environ["FIDELITY_PASSWORD"]
-        print("Fidelity has logged out!")
-        print("Logging in to Fidelity...")
-        username_field = driver.find_element(by=By.CSS_SELECTOR, value="#userId-input")
-        username_field.send_keys(FIDELITY_USERNAME)
-        password_field = driver.find_element(by=By.CSS_SELECTOR, value="#password")
-        password_field.send_keys(FIDELITY_PASSWORD)
-        driver.find_element(by=By.CSS_SELECTOR, value="#fs-login-button").click()
-        sleep(5)
-        if not "summary" in driver.current_url:
-            WebDriverWait(driver, 60).until(
-                expected_conditions.url_contains("summary")
-            )
-    except TimeoutException:
-        print("Fidelity is still logged in.")
-        pass
-    
     ret_acc = True
     # Make sure init didn't return None
     if driver is None:
@@ -183,31 +159,6 @@ async def fidelity_transaction(driver, action, stock, amount, price, time, DRY=T
     print("Fidelity")
     print("==============================")
     print()
-
-
-    # relogin if fidelity has logged out
-    try:
-        WebDriverWait(driver, 5).until(
-            expected_conditions.presence_of_element_located((By.CSS_SELECTOR, "#userId-input"))
-                                        )
-        FIDELITY_USERNAME = os.environ["FIDELITY_USERNAME"]
-        FIDELITY_PASSWORD = os.environ["FIDELITY_PASSWORD"]
-        print("Fidelity has logged out!")
-        print("Logging in to Fidelity...")
-        username_field = driver.find_element(by=By.CSS_SELECTOR, value="#userId-input")
-        username_field.send_keys(FIDELITY_USERNAME)
-        password_field = driver.find_element(by=By.CSS_SELECTOR, value="#password")
-        password_field.send_keys(FIDELITY_PASSWORD)
-        driver.find_element(by=By.CSS_SELECTOR, value="#fs-login-button").click()
-        sleep(5)
-        if not "summary" in driver.current_url:
-            WebDriverWait(driver, 60).until(
-                expected_conditions.url_contains("summary")
-            )
-    except TimeoutException:
-        print("Fidelity is still logged in.")
-        pass
-
     action = action.lower()
     stock = stock.upper()
     amount = int(amount)
@@ -311,10 +262,11 @@ async def fidelity_transaction(driver, action, stock, amount, price, time, DRY=T
             sleep(1)
             # Place order
             if not DRY:
+                # Check for error popup and clear it if the account cannot sell the stock for some reason.
                 try:
                     place_button = driver.find_element(by=By.CSS_SELECTOR, value="#placeOrderBtn")
                     place_button.click()
-            
+
                     # Wait for page to load
                     WebDriverWait(driver, 10).until(check_if_page_loaded)
                     sleep(1)
@@ -335,7 +287,6 @@ async def fidelity_transaction(driver, action, stock, amount, price, time, DRY=T
                     if ctx:
                         await ctx.send(message)
                 # Send confirmation
-                           
             else:
                 message = f"DRY: Fidelity {account_label}: {action} {amount} shares of {stock}"
                 print(message)
@@ -346,10 +297,6 @@ async def fidelity_transaction(driver, action, stock, amount, price, time, DRY=T
             print(e)
             traceback.print_exc()
             continue
-    message = f"Fidelity: {action} {amount} shares of {stock}. Operation complete!"
-    print(message)
-    if ctx:
-        await ctx.send(message)
 
 # fidelity = fidelity_init()
 # #     #input("Press enter to continue to holdings...")

--- a/fidelityAPI.py
+++ b/fidelityAPI.py
@@ -30,19 +30,19 @@ def fidelity_init(DOCKER=False):
         driver.get("https://digital.fidelity.com/prgw/digital/login/full-page?AuthRedUrl=https://digital.fidelity.com/ftgw/digital/portfolio/summary")
         # Wait for page load
         WebDriverWait(driver, 20).until(check_if_page_loaded)
-        # Type in username and password and click login 
+        # Type in username and password and click login
+        WebDriverWait(driver, 10).until(
+            expected_conditions.element_to_be_clickable((By.CSS_SELECTOR, "#userId-input"))
+        )
         username_field = driver.find_element(by=By.CSS_SELECTOR, value="#userId-input")
-        WebDriverWait(driver, 20).until(
-            expected_conditions.element_to_be_clickable(username_field)
-        )
         username_field.send_keys(FIDELITY_USERNAME)
-        password_field = driver.find_element(by=By.CSS_SELECTOR, value="#password")
-        WebDriverWait(driver, 20).until(
-            expected_conditions.element_to_be_clickable(password_field)
+        WebDriverWait(driver, 10).until(
+            expected_conditions.element_to_be_clickable((By.CSS_SELECTOR, "#password"))
         )
+        password_field = driver.find_element(by=By.CSS_SELECTOR, value="#password")
         password_field.send_keys(FIDELITY_PASSWORD)
         driver.find_element(by=By.CSS_SELECTOR, value="#fs-login-button").click()
-        WebDriverWait(driver, 20).until(check_if_page_loaded)
+        WebDriverWait(driver, 10).until(check_if_page_loaded)
         sleep(6)
         # Wait for page to load to summary page
         if not "summary" in driver.current_url:

--- a/fidelityAPI.py
+++ b/fidelityAPI.py
@@ -43,7 +43,7 @@ def fidelity_init(DOCKER=False):
         password_field.send_keys(FIDELITY_PASSWORD)
         driver.find_element(by=By.CSS_SELECTOR, value="#fs-login-button").click()
         WebDriverWait(driver, 10).until(check_if_page_loaded)
-        sleep(6)
+        sleep(3)
         # Wait for page to load to summary page
         if not "summary" in driver.current_url:
             WebDriverWait(driver, 60).until(
@@ -54,7 +54,7 @@ def fidelity_init(DOCKER=False):
             WebDriverWait(driver, 30).until(
                 expected_conditions.presence_of_element_located((By.LINK_TEXT, "Try Beta view"))
                                             )
-            print("Fidelity site is not in beta view, skipping...")
+            print("Beta view already disabled!")
         except TimeoutException:
             print("Disabling beta view...")
             driver.find_element(by=By.CSS_SELECTOR, value="#optout-btn").click()
@@ -64,7 +64,7 @@ def fidelity_init(DOCKER=False):
                 WebDriverWait(driver, 60).until(
                     expected_conditions.url_contains("oltx")
                 )
-            WebDriverWait(driver, 20).until(check_if_page_loaded)
+            WebDriverWait(driver, 10).until(check_if_page_loaded)
             print("Disabled beta view!")
         sleep(3)
         print("Logged in to Fidelity!")

--- a/fidelityAPI.py
+++ b/fidelityAPI.py
@@ -58,7 +58,7 @@ def fidelity_init(DOCKER=False):
         except TimeoutException:
             print("Disabling beta view...")
             driver.find_element(by=By.CSS_SELECTOR, value="#optout-btn").click()
-            WebDriverWait(driver, 20).until(check_if_page_loaded)
+            WebDriverWait(driver, 10).until(check_if_page_loaded)
             # Wait for page to be in old view
             if not "oltx" in driver.current_url:
                 WebDriverWait(driver, 60).until(

--- a/fidelityAPI.py
+++ b/fidelityAPI.py
@@ -104,7 +104,7 @@ async def fidelity_holdings(driver, ctx):
         try:
             test2 = ret_accounts[0].text
         except IndexError:
-            print("It seems there are no retirement accounts...")
+            print("No retirement accounts found, skipping...")
             ret_acc = False
         # Split by new line
         info = test.splitlines()
@@ -282,7 +282,10 @@ async def fidelity_transaction(driver, action, stock, amount, price, time, DRY=T
                                                     )   
                     error_dismiss = driver.find_element(by=By.XPATH, value="(//button[@class='pvd-modal__close-button'])[5]")
                     driver.execute_script("arguments[0].click();", error_dismiss)
-                    message = f"Fidelity {account_label}: {action} {amount} shares of {stock}. DID NOT COMPLETE! \nThis account does not have enough shares to complete this order."
+                    if action == "sell":
+                        message = f"Fidelity {account_label}: {action} {amount} shares of {stock}. DID NOT COMPLETE! \nEither this account does not have enough shares, or an order is already pending."
+                    elif action == "buy":
+                        message = f"Fidelity {account_label}: {action} {amount} shares of {stock}. DID NOT COMPLETE! \nEither this account does not have enough cash, or an order is already pending."
                     print(message)
                     if ctx:
                         await ctx.send(message)


### PR DESCRIPTION
1. Changed order of Waits on fidelityinit to wait for the element to be clickable before assigning it to a variable this avoids a no such element exception.
2. Changed check for try beta view to look at the beta-view selector instead of the website link. In testing this worked better.
3. retirement account check added to keep the bot from erroring if there are no retirement accounts
4. Changed selling and buying to take into account whether an account errored on selling/buying. If it does it clicks the dismiss prompt and moves on to the next account. Used javascript script to click on the elements to avoid click intercepted error.