### PR TITLE
fidelity and tradier small fixes

### DIFF
--- a/fidelityAPI.py
+++ b/fidelityAPI.py
@@ -274,9 +274,9 @@ async def fidelity_transaction(driver, action, stock, amount, price, time, DRY=T
                 except NoSuchElementException:
                     # Check for error
                     WebDriverWait(driver, 10).until(
-                        expected_conditions.presence_of_element_located((By.XPATH, "(//div[@class='pvd-modal__content'])[5]"))
+                        expected_conditions.presence_of_element_located((By.XPATH, "(//button[@class='pvd-modal__close-button'])[3]"))
                     )   
-                    error_dismiss = driver.find_element(by=By.XPATH, value="(//button[@class='pvd-modal__close-button'])[5]")
+                    error_dismiss = driver.find_element(by=By.XPATH, value="(//button[@class='pvd-modal__close-button'])[3]")
                     driver.execute_script("arguments[0].click();", error_dismiss)
                     if action == "sell":
                         message = f"Fidelity {account_label}: {action} {amount} shares of {stock}. DID NOT COMPLETE! \nEither this account does not have enough shares, or an order is already pending."

--- a/tradierAPI.py
+++ b/tradierAPI.py
@@ -147,15 +147,20 @@ async def tradier_transaction(tradier, action, stock, amount, price, time, DRY=T
             json_response = response.json()
             #print(response.status_code)
             #print(json_response)
-            if json_response['order']['status'] == "ok":
-                print(f"Tradier account {account_number}: {action} {amount} of {stock}")
+            try:
+                if json_response['order']['status'] == "ok":
+                    print(f"Tradier account {account_number}: {action} {amount} of {stock}")
+                    if ctx:
+                        await ctx.send(f"Tradier account {account_number}: {action} {amount} of {stock}")
+                else:
+                    print(f"Tradier account {account_number} Error: {json_response['order']['status']}")
+                    if ctx:
+                        await ctx.send(f"Tradier account {account_number} Error: {json_response['order']['status']}")
+                    return None
+            except KeyError:
+                print(f"Tradier account {account_number} Error: This order did not route. Is this a new account?")
                 if ctx:
-                    await ctx.send(f"Tradier account {account_number}: {action} {amount} of {stock}")
-            else:
-                print(f"Tradier account {account_number} Error: {json_response['order']['status']}")
-                if ctx:
-                    await ctx.send(f"Tradier account {account_number} Error: {json_response['order']['status']}")
-                return None
+                    await ctx.send(f"Tradier account {account_number} Error: This order did not route. Is this a new account?") 
         else:
             print(f"Tradier account {account_number}: Running in DRY mode. Trasaction would've been: {action} {amount} of {stock}")
             if ctx:


### PR DESCRIPTION
The warning window that pops up if an order cannot be routed's element changed, fixed the two lines to find it.

If there is a new account that cannot trade yet on tradier it will error. The try/except block skips it and warns the user that the account cannot make the trade yet.