### PR TITLE
Mask Account Numbers when Printed

### DIFF
--- a/fidelityAPI.py
+++ b/fidelityAPI.py
@@ -23,6 +23,7 @@ from helperAPI import (
     killSeleniumDriver,
     printAndDiscord,
     printHoldings,
+    maskString,
     stockOrder,
     type_slowly,
 )
@@ -315,7 +316,7 @@ def fidelity_transaction(fidelity_o: Brokerage, orderObj: stockOrder, loop=None)
                         by=By.CSS_SELECTOR, value="li"
                     )
                     account_number = fidelity_o.get_account_numbers(key)[x]
-                    account_label = fidelity_o.print_account_number(account_number)
+                    account_label = maskString(account_number)
                     accounts_dropdown_in[x].click()
                     sleep(1)
                     # Type in ticker

--- a/fidelityAPI.py
+++ b/fidelityAPI.py
@@ -314,7 +314,7 @@ def fidelity_transaction(fidelity_o: Brokerage, orderObj: stockOrder, loop=None)
                     accounts_dropdown_in = test.find_elements(
                         by=By.CSS_SELECTOR, value="li"
                     )
-                    account_number = accounts_dropdown_in[x].text
+                    account_number = fidelity_o.get_account_numbers(key)[x]
                     account_label = fidelity_o.print_account_number(account_number)
                     accounts_dropdown_in[x].click()
                     sleep(1)
@@ -517,13 +517,13 @@ def fidelity_transaction(fidelity_o: Brokerage, orderObj: stockOrder, loop=None)
                                 "arguments[0].click();", error_dismiss
                             )
                             printAndDiscord(
-                                f"{key} {account_label}: {orderObj.get_action()} {orderObj.get_amount()} shares of {s}. DID NOT COMPLETE! \nEither this account does not have enough shares, or an order is already pending.",
+                                f"{key} account {account_label}: {orderObj.get_action()} {orderObj.get_amount()} shares of {s}. DID NOT COMPLETE! \nEither this account does not have enough shares, or an order is already pending.",
                                 loop,
                             )
                         # Send confirmation
                     else:
                         printAndDiscord(
-                            f"DRY: {key} {account_label}: {orderObj.get_action()} {orderObj.get_amount()} shares of {s}",
+                            f"DRY: {key} account {account_label}: {orderObj.get_action()} {orderObj.get_amount()} shares of {s}",
                             loop,
                         )
                     sleep(3)

--- a/helperAPI.py
+++ b/helperAPI.py
@@ -282,14 +282,6 @@ class Brokerage:
             return self.__account_types.get(parent_name, {})
         return self.__account_types.get(parent_name, {}).get(account_name, "")
 
-    def print_account_number(self, an) -> str:
-        # Print 12345678 as xxxx5678
-        an = str(an)
-        if len(an) < 4:
-            return an
-        masked = "x" * (len(an) - 4) + an[-4:]
-        return masked
-
     def __str__(self) -> str:
         return textwrap.dedent(
             f"""
@@ -458,6 +450,15 @@ async def processQueue():
         task_queue.task_done()
 
 
+def maskString(string):
+    # Mask string (12345678 -> xxxx5678)
+    string = str(string)
+    if len(string) < 4:
+        return string
+    masked = "x" * (len(string) - 4) + string[-4:]
+    return masked
+
+
 def printHoldings(brokerObj: Brokerage, loop=None):
     # Helper function for holdings formatting
     printAndDiscord(
@@ -466,7 +467,7 @@ def printHoldings(brokerObj: Brokerage, loop=None):
     )
     for key in brokerObj.get_account_numbers():
         for account in brokerObj.get_account_numbers(key):
-            printAndDiscord(f"{key} ({brokerObj.print_account_number(account)}):", loop)
+            printAndDiscord(f"{key} ({maskString(account)}):", loop)
             holdings = brokerObj.get_holdings(key, account)
             if holdings == {}:
                 printAndDiscord("No holdings in Account\n", loop)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pyotp==2.9.0
 python-dotenv==1.0.0
 requests==2.31.0
 robin_stocks==3.0.6
-schwab-api==0.3.6
+schwab-api==0.3.8
 selenium==4.12.0
 tastytrade==6.1
 webdriver-manager==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pyotp==2.9.0
 python-dotenv==1.0.0
 requests==2.31.0
 robin_stocks==3.0.6
-schwab-api==0.3.3
+schwab-api==0.3.5
 selenium==4.12.0
 tastytrade==6.1
 webdriver-manager==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pyotp==2.9.0
 python-dotenv==1.0.0
 requests==2.31.0
 robin_stocks==3.0.6
-schwab-api==0.3.5
+schwab-api==0.3.6
 selenium==4.12.0
 tastytrade==6.1
 webdriver-manager==4.0.0

--- a/robinhoodAPI.py
+++ b/robinhoodAPI.py
@@ -8,7 +8,7 @@ import pyotp
 import robin_stocks.robinhood as rh
 from dotenv import load_dotenv
 
-from helperAPI import Brokerage, printAndDiscord, printHoldings, stockOrder
+from helperAPI import Brokerage, printAndDiscord, printHoldings, maskString, stockOrder
 
 
 def robinhood_init(ROBINHOOD_EXTERNAL=None):
@@ -52,7 +52,7 @@ def robinhood_init(ROBINHOOD_EXTERNAL=None):
             )
             atype = rh.account.load_account_profile(info="type", account_number=an)
             rh_obj.set_account_type(name, an, atype)
-            print(f"Found {atype} account {rh_obj.print_account_number(an)}")
+            print(f"Found {atype} account {maskString(an)}")
             # Check for IRA accounts
             if (len(account) > 3) and (account[3] != "NA"):
                 iras = [account[3]]
@@ -61,7 +61,7 @@ def robinhood_init(ROBINHOOD_EXTERNAL=None):
                 for ira in iras:
                     # Make sure it's different from the normal account number
                     if ira == an:
-                        ira = rh_obj.print_account_number(ira)
+                        ira = maskString(ira)
                         print(
                             f"ERROR: IRA account {ira} is the same as margin account. Please remove {an} from your .env file."
                         )
@@ -71,10 +71,10 @@ def robinhood_init(ROBINHOOD_EXTERNAL=None):
                     )
                     if ira_num is None:
                         print(
-                            f"Unable to lookup IRA account {rh_obj.print_account_number(ira)}"
+                            f"Unable to lookup IRA account {maskString(ira)}"
                         )
                         continue
-                    print(f"Found IRA account {rh_obj.print_account_number(ira_num)}")
+                    print(f"Found IRA account {maskString(ira_num)}")
                     rh_obj.set_account_number(name, ira_num)
                     rh_obj.set_account_totals(
                         name,
@@ -139,7 +139,7 @@ def robinhood_transaction(rho: Brokerage, orderObj: stockOrder, loop=None):
             )
             for account in rho.get_account_numbers(key):
                 obj: rh = rho.get_logged_in_objects(key)
-                print_account = rho.print_account_number(account)
+                print_account = maskString(account)
                 if not orderObj.get_dry():
                     try:
                         # Market order

--- a/schwabAPI.py
+++ b/schwabAPI.py
@@ -49,7 +49,6 @@ def schwab_init(SCHWAB_EXTERNAL=None):
                     name, account, account_info[account]["account_value"]
                 )
         except Exception as e:
-            print(traceback.format_exc())
             print(f"Error logging in to Schwab: {e}")
             print(traceback.format_exc())
             return None

--- a/schwabAPI.py
+++ b/schwabAPI.py
@@ -8,7 +8,7 @@ from time import sleep
 from dotenv import load_dotenv
 from schwab_api import Schwab
 
-from helperAPI import Brokerage, printAndDiscord, printHoldings, stockOrder
+from helperAPI import Brokerage, printAndDiscord, printHoldings, maskString, stockOrder
 
 
 def schwab_init(SCHWAB_EXTERNAL=None):
@@ -39,7 +39,7 @@ def schwab_init(SCHWAB_EXTERNAL=None):
             )
             account_info = schwab.get_account_info_v2()
             account_list = list(account_info.keys())
-            print_accounts = [schwab_obj.print_account_number(a) for a in account_list]
+            print_accounts = [maskString(a) for a in account_list]
             print(f"The following Schwab accounts were found: {print_accounts}")
             print("Logged in to Schwab!")
             schwab_obj.set_logged_in_object(name, schwab)
@@ -96,7 +96,7 @@ def schwab_transaction(schwab_o: Brokerage, orderObj: stockOrder, loop=None):
             )
             obj: Schwab = schwab_o.get_logged_in_objects(key)
             for account in schwab_o.get_account_numbers(key):
-                print_account = schwab_o.print_account_number(account)
+                print_account = maskString(account)
                 # If DRY is True, don't actually make the transaction
                 if orderObj.get_dry():
                     printAndDiscord(

--- a/schwabAPI.py
+++ b/schwabAPI.py
@@ -2,6 +2,7 @@
 # Schwab API
 
 import os
+import traceback
 from time import sleep
 
 from dotenv import load_dotenv
@@ -47,6 +48,7 @@ def schwab_init(SCHWAB_EXTERNAL=None):
                     name, account, account_info[account]["account_value"]
                 )
         except Exception as e:
+            print(traceback.format_exc())
             print(f"Error logging in to Schwab: {e}")
             return None
     return schwab_obj

--- a/tastyAPI.py
+++ b/tastyAPI.py
@@ -21,7 +21,7 @@ from tastytrade.order import (
 from tastytrade.streamer import DataStreamer
 from tastytrade.utils import TastytradeError
 
-from helperAPI import Brokerage, printAndDiscord, printHoldings, stockOrder
+from helperAPI import Brokerage, printAndDiscord, printHoldings, maskString, stockOrder
 
 
 def order_setup(tt: ProductionSession, order_type, stock_price, stock, amount):
@@ -121,7 +121,7 @@ async def tastytrade_execute(tt_o: Brokerage, orderObj: stockOrder, loop=None):
                 loop=loop,
             )
             for i, acct in enumerate(tt_o.get_account_numbers(key)):
-                print_account = tt_o.print_account_number(acct)
+                print_account = maskString(acct)
                 try:
                     acct: Account = accounts[i]
                     # Set order type

--- a/tradierAPI.py
+++ b/tradierAPI.py
@@ -9,7 +9,7 @@ from time import sleep
 import requests
 from dotenv import load_dotenv
 
-from helperAPI import Brokerage, printAndDiscord, printHoldings, stockOrder
+from helperAPI import Brokerage, printAndDiscord, printHoldings, maskString, stockOrder
 
 
 def make_request(
@@ -85,7 +85,7 @@ def tradier_init(TRADIER_EXTERNAL=None):
                 an = json_response["profile"]["account"]["account_number"]
             else:
                 an = json_response["profile"]["account"][x]["account_number"]
-            print(tradier_obj.print_account_number(an))
+            print(maskString(an))
             tradier_obj.set_account_number(name, an)
             tradier_obj.set_account_type(
                 name, an, json_response["profile"]["account"][x]["type"]
@@ -175,7 +175,7 @@ def tradier_transaction(tradier_o: Brokerage, orderObj: stockOrder, loop=None):
             )
             for account in tradier_o.get_account_numbers(key):
                 obj: str = tradier_o.get_logged_in_objects(key)
-                print_account = tradier_o.print_account_number(account)
+                print_account = maskString(account)
                 # Tradier doesn't support fractional shares
                 if not orderObj.get_amount().is_integer():
                     printAndDiscord(


### PR DESCRIPTION
Prints `12345678` as `xxxx5678` for more privacy when sharing logs or screenshots.