### PR TITLE
fix messaging on unsuccessful order

### DIFF
--- a/chaseAPI.py
+++ b/chaseAPI.py
@@ -198,10 +198,10 @@ def chase_transaction(chase_o: Brokerage, orderObj: stockOrder, loop=None):
                         printAndDiscord(
                             (
                                 f"{key} account {account}: The order verification was "
-                                + "successful"
-                                if messages["ORDER PREVIEW"]
-                                not in ["", "No order preview page found."]
-                                else "unsuccessful"
+                                + ("successful"
+                                    if messages["ORDER PREVIEW"]
+                                    not in ["", "No order preview page found."]
+                                    else "unsuccessful")
                             ),
                             loop,
                         )
@@ -218,13 +218,13 @@ def chase_transaction(chase_o: Brokerage, orderObj: stockOrder, loop=None):
                         printAndDiscord(
                             (
                                 f"{key} account {account}: The order verification was "
-                                + "successful"
-                                if messages["ORDER CONFIRMATION"]
-                                not in [
-                                    "",
-                                    "No order confirmation page found. Order Failed.",
-                                ]
-                                else "unsuccessful"
+                                + ("successful"
+                                    if messages["ORDER CONFIRMATION"]
+                                    not in [
+                                        "",
+                                        "No order confirmation page found. Order Failed.",
+                                    ]
+                                    else "unsuccessful")
                             ),
                             loop,
                         )


### PR DESCRIPTION
Fixes the messaging to print out the account number correctly on an unsuccessful order.