### PR TITLE
Trim Dockerfile and Move to Native Selenium Webdriver Management

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@
 
 # Main files
 !autoRSA.py
-!Dockerfile
 !entrypoint.sh
 !requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # Nelson Dane
 
-# Build from the playwright image
-FROM mcr.microsoft.com/playwright:v1.43.1-jammy
+# Build from python slim image
+FROM python:3.12-slim
+
 # Set ENV variables
 ENV TZ=America/New_York
 ENV DEBIAN_FRONTEND=noninteractive
@@ -9,53 +10,29 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Default display to :99
 ENV DISPLAY :99
 
-# CD into app
-WORKDIR /app
-
 # Install python, pip, and tzdata
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    xvfb \
-    xfonts-cyrillic \
-    xfonts-100dpi \
-    xfonts-75dpi \
-    xfonts-base \
-    xfonts-scalable \
-    gtk2-engines-pixbuf \
-    wget \
-    gpg \
-    python3-pip \
+    chromium \
+    dos2unix \
+    git \
     tzdata \
-    software-properties-common \
+    xvfb \
 && rm -rf /var/lib/apt/lists/*
 
-# Install Chromium
-RUN add-apt-repository ppa:savoury1/chromium
-RUN apt-get update && apt-get install -y --no-install-recommends chromium-browser chromium-chromedriver && rm -rf /var/lib/apt/lists/*
+# CD into app
+WORKDIR /app
+COPY . .
 
 # Install python dependencies
-COPY ./requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Install playwright
 RUN playwright install && \
     playwright install-deps
 
-# Grab needed files
-COPY ./autoRSA.py .
-COPY ./entrypoint.sh .
-COPY ./chaseAPI.py .
-COPY ./fidelityAPI.py .
-COPY ./firstradeAPI.py .
-COPY ./helperAPI.py .
-COPY ./publicAPI.py .
-COPY ./robinhoodAPI.py .
-COPY ./schwabAPI.py .
-COPY ./tastyAPI.py .
-COPY ./tradierAPI.py .
-COPY ./webullAPI.py .
-
 # Make the entrypoint executable
-RUN chmod +x entrypoint.sh
+RUN dos2unix entrypoint.sh && \
+    chmod +x entrypoint.sh
 
 # Set the entrypoint to our entrypoint.sh
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,16 +19,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xvfb \
 && rm -rf /var/lib/apt/lists/*
 
-# CD into app
-WORKDIR /app
-COPY . .
-
 # Install python dependencies
-RUN pip install --no-cache-dir -r requirements.txt
+COPY ./requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
 
 # Install playwright
 RUN playwright install && \
     playwright install-deps
+
+# CD into app
+WORKDIR /app
+COPY . .
 
 # Make the entrypoint executable
 RUN dos2unix entrypoint.sh && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,8 @@
-version: "3.3"
 services:
     auto-rsa:
         container_name: auto-rsa
-        image: docker.io/nelsondane/auto-rsa:latest # change to develop for latest development version
-        # build: . # uncomment this line if you want to build the image locally with docker-compose up -d --build
+        image: docker.io/nelsondane/auto-rsa:latest # or change to other branch you want to use
+        # build: . # uncomment this line if you want to build the image locally with "docker compose up -d --build"
         restart: unless-stopped
         env_file:
             - .env

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-rm /tmp/.X99-lock
+rm -f /tmp/.X99-lock
 echo "Starting X virtual framebuffer (Xvfb) in background..."
 Xvfb -ac :99 -screen 0 1280x1024x16 &
 export DISPLAY=:99
 echo "Starting Auto RSA Bot..."
-python3 autoRSA.py docker
+python autoRSA.py docker

--- a/helperAPI.py
+++ b/helperAPI.py
@@ -20,7 +20,6 @@ from dotenv import load_dotenv
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service as ChromiumService
 from selenium.webdriver.edge.service import Service as EdgeService
-from webdriver_manager.microsoft import EdgeChromiumDriverManager
 
 # Create task queue
 task_queue = Queue()
@@ -499,7 +498,7 @@ def getDriver(DOCKER=False):
             options.add_argument("--disable-gpu")
             # Docker uses specific chromedriver installed via apt
             driver = webdriver.Chrome(
-                service=ChromiumService("/usr/bin/chromedriver"),
+                service=ChromiumService(),
                 options=options,
             )
         else:
@@ -508,7 +507,7 @@ def getDriver(DOCKER=False):
             options.add_argument("--disable-blink-features=AutomationControlled")
             options.add_argument("--disable-notifications")
             driver = webdriver.Edge(
-                service=EdgeService(EdgeChromiumDriverManager().install()),
+                service=EdgeService(),
                 options=options,
             )
     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,5 @@ requests==2.31.0
 -e git+https://github.com/NelsonDane/robin_stocks.git@f490a2eb0d5fc53afc93e077b3ea2a555124e105#egg=robin-stocks
 schwab-api==0.4.0
 selenium==4.20.0
-setuptools==69.5.1
 tastytrade==8.0
 -e git+https://github.com/NelsonDane/webull.git@ef14ae63f9e1436fbea77fe864df54847cf2f730#egg=webull
-webdriver-manager==4.0.1


### PR DESCRIPTION
* Changes the base image to `python:3.12-slim`
* Removes unneeded installs and layers from the Dockerfile
* Adds `dos2unix` to fix entrypoint line endings issues on Windows
* Uses the built in native selenium webdriver manager instead of the 3rd party one