### PR TITLE
Fix Selenium Docker on ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV DISPLAY :99
 # Install python, pip, and tzdata
 RUN apt-get update && apt-get install -y --no-install-recommends \
     chromium \
+    chromium-driver \
     dos2unix \
     git \
     tzdata \
@@ -24,7 +25,7 @@ COPY ./requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
 # Install playwright
-RUN playwright install && \
+RUN playwright install firefox && \
     playwright install-deps
 
 # CD into app

--- a/fidelityAPI.py
+++ b/fidelityAPI.py
@@ -83,16 +83,16 @@ def fidelity_init(FIDELITY_EXTERNAL=None, DOCKER=False):
             try:
                 WebDriverWait(driver, 10).until(
                     expected_conditions.element_to_be_clickable(
-                        (By.CSS_SELECTOR, "#userId-input")
+                        (By.CSS_SELECTOR, "#dom-username-input")
                     )
                 )
-                username_selector = "#userId-input"
-                password_selector = "#password"
-                login_btn_selector = "#fs-login-button"
-            except TimeoutException:
                 username_selector = "#dom-username-input"
                 password_selector = "#dom-pswd-input"
                 login_btn_selector = "#dom-login-button > div"
+            except TimeoutException:
+                username_selector = "#userId-input"
+                password_selector = "#password"
+                login_btn_selector = "#fs-login-button"
             WebDriverWait(driver, 10).until(
                 expected_conditions.element_to_be_clickable(
                     (By.CSS_SELECTOR, username_selector)
@@ -109,8 +109,8 @@ def fidelity_init(FIDELITY_EXTERNAL=None, DOCKER=False):
             driver.find_element(by=By.CSS_SELECTOR, value=login_btn_selector).click()
             WebDriverWait(driver, 10).until(check_if_page_loaded)
             sleep(3)
-            # Retry the login if we get an error page
             try:
+                # Look for: Sorry, we can't complete this action right now. Please try again.
                 go_back_selector = "#dom-sys-err-go-to-login-button > span > s-slot > s-assigned-wrapper"
                 WebDriverWait(driver, 10).until(
                     expected_conditions.element_to_be_clickable(

--- a/fidelityAPI.py
+++ b/fidelityAPI.py
@@ -310,7 +310,6 @@ def fidelity_transaction(fidelity_o: Brokerage, orderObj: stockOrder, loop=None)
                     by=By.CSS_SELECTOR, value="#ett-acct-sel-list"
                 )
                 accounts_list = test.find_elements(by=By.CSS_SELECTOR, value="li")
-                print(f"Number of accounts: {len(accounts_list)}")
                 number_of_accounts = len(accounts_list)
                 # Click a second time to clear the account list
                 driver.execute_script("arguments[0].click();", accounts_dropdown)
@@ -354,10 +353,14 @@ def fidelity_transaction(fidelity_o: Brokerage, orderObj: stockOrder, loop=None)
                     try:
                         driver.find_element(
                             by=By.CSS_SELECTOR,
-                            value="body > div.app-body > ap122489-ett-component > div > order-entry > div.eq-ticket.order-entry__container-height > div > div > form > div.order-entry__container-content.scroll > div:nth-child(2) > symbol-search > div > div.eq-ticket--border-top > div > div:nth-child(2) > div > div > div > pvd3-inline-alert > s-root > div > div.pvd-inline-alert__content > s-slot > s-assigned-wrapper",
+                            value="body > div.app-body > ap122489-ett-component > div > order-entry-base > div > div > div.order-entry__container-content.scroll > div > equity-order-selection > div:nth-child(1) > symbol-search > div > div.eq-ticket--border-top > div > div:nth-child(2) > div > div > div > pvd3-inline-alert > s-root > div > div.pvd-inline-alert__content > s-slot > s-assigned-wrapper",
                         )
-                        print(f"Error: Symbol {s} not found")
-                        return
+                        printAndDiscord(
+                            f"{key} Error: Symbol {s} not found", loop
+                        )
+                        print()
+                        killSeleniumDriver(fidelity_o)
+                        return None
                     except Exception:
                         pass
                     # Get last price

--- a/helperAPI.py
+++ b/helperAPI.py
@@ -498,7 +498,7 @@ def getDriver(DOCKER=False):
             options.add_argument("--disable-gpu")
             # Docker uses specific chromedriver installed via apt
             driver = webdriver.Chrome(
-                service=ChromiumService(),
+                service=ChromiumService("/usr/bin/chromedriver"),
                 options=options,
             )
         else:


### PR DESCRIPTION
This update uses the `chromedriver` via apt when in Docker, which supports ARM devices. This should fix https://github.com/NelsonDane/auto-rsa/issues/221 as well.

In Fidelity, now that the updated view is the default, check for that first before falling back to the old view, instead of the other way around. Also fixes the CSS path for the "Symbol not found" error.

When installing playwright in the Dockerfile, only install Firefox, since no other browser is used by playwright. This cuts that layer size in half, bringing the image size down to ~600mb vs ~900mb.