### PR TITLE
fix multi ticker chase error

### DIFF
--- a/chaseAPI.py
+++ b/chaseAPI.py
@@ -246,11 +246,10 @@ def chase_transaction(chase_o: Brokerage, orderObj: stockOrder, loop=None):
                                 loop,
                             )
             except Exception as e:
-                obj.close_browser()
                 printAndDiscord(f"{key} {account}: Error submitting order: {e}", loop)
                 print(traceback.format_exc())
                 continue
-        obj.close_browser()
+    obj.close_browser()
     printAndDiscord(
         "All Chase transactions complete",
         loop,


### PR DESCRIPTION
- Removes the first `obj.close_browser()` so that it can continue to buy stocks even if it errors on one account (Or attempt too at least)
- Moves the second `obj.close_browser()` back one indent so it will not close the browser until all tickers are bought.