### PR TITLE
Update autoRSA.py (Which brokers are called with different commands)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,15 @@ Note: There are two special keywords you can use when specifying accounts: `all`
 - Fennel
 - Firstrade
 - Public
-- Robinhood
 - Schwab
 - Tastytrade
 - Tradier
 - Webull
 
 This is useful for brokers that provide quick turnaround times, hence the nickname "day 1".
+A couple other keywords that can be used:
+`most`: will use every account you have setup except for "vanguard".
+`fast`: will use every "day 1" broker + robinhood.
 
 ## 🗺️ Other Guides 🗺️
 More detailed guides for some of the difficult setups:

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Note: There are two special keywords you can use when specifying accounts: `all`
 
 This is useful for brokers that provide quick turnaround times, hence the nickname "day 1".
 A couple other keywords that can be used:
-`most`: will use every account you have setup except for "vanguard".
+`most`: will use every account you have setup except for vanguard.
 `fast`: will use every "day 1" broker + robinhood.
 
 ## 🗺️ Other Guides 🗺️

--- a/autoRSA.py
+++ b/autoRSA.py
@@ -196,6 +196,10 @@ def argParser(args: list) -> stockOrder:
         orderObj.set_brokers(SUPPORTED_BROKERS)
     elif args[3] == "day1":
         orderObj.set_brokers(DAY1_BROKERS)
+    elif args[3] == "most":
+        orderObj.set_brokers(list(filter(lambda x: x != 'vanguard', SUPPORTED_BROKERS)))
+    elif args[3] == "fast":
+        orderObj.set_brokers(DAY1_BROKERS + ["robinhood"])
     else:
         for broker in args[3].split(","):
             if nicknames(broker) in SUPPORTED_BROKERS:

--- a/autoRSA.py
+++ b/autoRSA.py
@@ -65,7 +65,6 @@ DAY1_BROKERS = [
     "tradier",
     "webull",
 ]
-
 DISCORD_BOT = False
 DOCKER_MODE = False
 DANGER_MODE = False

--- a/autoRSA.py
+++ b/autoRSA.py
@@ -52,7 +52,6 @@ SUPPORTED_BROKERS = [
     "schwab",
     "tastytrade",
     "tradier",
-    "vanguard",
     "webull",
 ]
 DAY1_BROKERS = [
@@ -60,7 +59,6 @@ DAY1_BROKERS = [
     "fennel",
     "firstrade",
     "public",
-    "robinhood",
     "schwab",
     "tastytrade",
     "tradier",

--- a/autoRSA.py
+++ b/autoRSA.py
@@ -52,6 +52,7 @@ SUPPORTED_BROKERS = [
     "schwab",
     "tastytrade",
     "tradier",
+    "vanguard",
     "webull",
 ]
 DAY1_BROKERS = [
@@ -64,6 +65,7 @@ DAY1_BROKERS = [
     "tradier",
     "webull",
 ]
+
 DISCORD_BOT = False
 DOCKER_MODE = False
 DANGER_MODE = False
@@ -177,6 +179,10 @@ def argParser(args: list) -> stockOrder:
             orderObj.set_brokers(SUPPORTED_BROKERS)
         elif args[1] == "day1":
             orderObj.set_brokers(DAY1_BROKERS)
+        elif args[1] == "most":
+            orderObj.set_brokers(list(filter(lambda x: x != 'vanguard', SUPPORTED_BROKERS)))
+        elif args[1] == "fast":
+            orderObj.set_brokers(DAY1_BROKERS + ["robinhood"])
         else:
             for broker in args[1].split(","):
                 orderObj.set_brokers(nicknames(broker))


### PR DESCRIPTION
1. Vanguard: This broker is blocking new RSA buys for everyone in my network. I still think it's beneficial to utilize the bot for specific VG orders but it doesn't make sense to include it in the 'all' command. Removing it from this section still allows you access to the VanguardAPI.
2. Robinhood: Not truly day 1 like the rest of them. Takes an extra day.

I am consistently adding 'NOT VG' and 'NOT RH' to the command.