### PR TITLE
Only send discord messages to specified channel

### DIFF
--- a/autoRSA.py
+++ b/autoRSA.py
@@ -294,6 +294,13 @@ if __name__ == "__main__":
                 os._exit(1)  # Special exit code to restart docker container
             await channel.send("Discord bot is started...")
 
+        # Process the message only if it's from the specified channel
+        @bot.event
+        async def on_message(message):
+            channel = bot.get_channel(DISCORD_CHANNEL)
+            if message.channel.id == channel.id:
+                await bot.process_commands(message)
+
         # Bot ping-pong
         @bot.command(name="ping")
         async def ping(ctx):

--- a/autoRSA.py
+++ b/autoRSA.py
@@ -297,8 +297,7 @@ if __name__ == "__main__":
         # Process the message only if it's from the specified channel
         @bot.event
         async def on_message(message):
-            channel = bot.get_channel(DISCORD_CHANNEL)
-            if message.channel.id == channel.id:
+            if message.channel.id == DISCORD_CHANNEL:
                 await bot.process_commands(message)
 
         # Bot ping-pong


### PR DESCRIPTION
This will ensure that the Discord bot will only be sending messages in the specified channel. As it is right now is that anyone who has access to a text channel the bot also is in would be able to send commands to the bot, such as `!rsa buy 1000 APPL`.