### PR TITLE
Add not support for holdings

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ To check your account holdings:
 
 `<prefix> holdings <accounts>`
 
+For example, to check your account holdings on Chase and Vanguard, but not Robinhood:
+
+`<prefix> holdings chase,vanguard not robinhood`
+
 To restart the Discord bot (only for the Docker Discord bot):
 
 `!restart` (without appending `!rsa` or prefix)

--- a/autoRSA.py
+++ b/autoRSA.py
@@ -160,8 +160,7 @@ def fun_run(orderObj: stockOrder, command, botObj=None, loop=None):
                 print(f"Error in {fun_name} with {broker}: {ex}")
                 print(orderObj)
             print()
-        if not orderObj.get_holdings():
-            printAndDiscord("All transactions complete in all brokers", loop)
+        printAndDiscord("All commands complete in all brokers", loop)
     else:
         print(f"Error: {command} is not a valid command")
 

--- a/autoRSA.py
+++ b/autoRSA.py
@@ -182,6 +182,13 @@ def argParser(args: list) -> stockOrder:
         else:
             for broker in args[1].split(","):
                 orderObj.set_brokers(nicknames(broker))
+
+        # If next argument is not, set not broker
+        if len(args) > 3 and args[2] == "not":
+            for broker in args[3].split(","):
+                if nicknames(broker) in SUPPORTED_BROKERS:
+                    orderObj.set_notbrokers(nicknames(broker))
+
         return orderObj
     # Otherwise: action, amount, stock, broker, (optional) not broker, (optional) dry
     orderObj.set_action(args[0])
@@ -314,7 +321,7 @@ if __name__ == "__main__":
                 "Available RSA commands:\n"
                 "!ping\n"
                 "!help\n"
-                "!rsa holdings [all|<broker1>,<broker2>,...]\n"
+                "!rsa holdings [all|<broker1>,<broker2>,...] [not broker1,broker2,...]\n"
                 "!rsa [buy|sell] [amount] [stock1|stock1,stock2] [all|<broker1>,<broker2>,...] [not broker1,broker2,...] [DRY: true|false]\n"
                 "!restart"
             )

--- a/autoRSA.py
+++ b/autoRSA.py
@@ -181,13 +181,11 @@ def argParser(args: list) -> stockOrder:
         else:
             for broker in args[1].split(","):
                 orderObj.set_brokers(nicknames(broker))
-
         # If next argument is not, set not broker
         if len(args) > 3 and args[2] == "not":
             for broker in args[3].split(","):
                 if nicknames(broker) in SUPPORTED_BROKERS:
                     orderObj.set_notbrokers(nicknames(broker))
-
         return orderObj
     # Otherwise: action, amount, stock, broker, (optional) not broker, (optional) dry
     orderObj.set_action(args[0])


### PR DESCRIPTION
As it is right now, it is not possible to use `not` for holdings. This PR makes it easier when dealing with issues such as #275 to run `!rsa holdings all not chase`.