### PR TITLE
Fix Fidelity incorrect ticker length limit

### DIFF
--- a/fidelityAPI.py
+++ b/fidelityAPI.py
@@ -255,11 +255,11 @@ def fidelity_holdings(fidelity_o: Brokerage, loop=None):
                 stocks_list = javascript_get_classname(
                     driver, "ag-pinned-left-cols-container"
                 )
-                # Find 3 or 4 letter words surrounded by 2 spaces on each side
+                # Find 1-5 letter words surrounded by 2 spaces on each side
                 for i in range(len(stocks_list)):
                     stocks_list[i].replace(" \n ", "").replace("*", "")
                     stocks_list[i] = re.findall(
-                        r"(?<=\s{2})[a-zA-Z]{3,4}(?=\s{2})", stocks_list[i]
+                        r"(?<=\s{2})[a-zA-Z]{1,5}(?=\s{2})", stocks_list[i]
                     )
                 stocks_list = stocks_list[0]
                 # holdings_info = javascript_get_classname(


### PR DESCRIPTION
### **Warning, I do not have Fidelity, can can someone please make sure to test this or wait a couple days for me to get Fidelity setup**

Solves issue where tickers that are 1-2 characters long (F [Ford], GA [Goldman Sachs Group]) or 5 characters in length (FZROX [Fidelity ZERO Total Market Index]) were not being grabbed as holdings, even when they were holdings.