### PR TITLE
Bypass Webull update

### DIFF
--- a/autoRSA.py
+++ b/autoRSA.py
@@ -34,7 +34,7 @@ try:
 except Exception as e:
     print(f"Error importing libraries: {e}")
     print(traceback.format_exc())
-    print("Please run 'pip install -r requirements.txt'")
+    print("Please run 'python install_dependencies.py'")
     sys.exit(1)
 
 # Initialize .env file

--- a/helperAPI.py
+++ b/helperAPI.py
@@ -340,7 +340,7 @@ def updater():
         from git import Repo
     except ImportError:
         print(
-            "UPDATE ERROR: Git is not installed. Please install Git and then run pip install -r requirements.txt"
+            "UPDATE ERROR: Git is not installed. Please install Git and then run python install_dependencies.py"
         )
         print()
         return
@@ -458,7 +458,7 @@ def check_package_versions():
             continue
     if not SHOULD_CONTINUE:
         print(
-            'Please run "pip install -r requirements.txt" to install/update required packages.'
+            'Please run "python install_dependencies.py" to install/update required packages.'
         )
         sys.exit(1)
     else:

--- a/install_dependencies.py
+++ b/install_dependencies.py
@@ -1,0 +1,61 @@
+import subprocess
+import sys
+import re
+import os
+
+def get_installed_webull_commit_hash():
+    try:
+        # Assuming webull is installed in the site-packages directory
+        from webull import __file__ as webull_file
+        webull_path = os.path.dirname(webull_file)
+        git_head_path = os.path.join(webull_path, '..', '.git', 'HEAD')
+
+        if os.path.isfile(git_head_path):
+            with open(git_head_path, 'r') as head_file:
+                ref = head_file.read().strip()
+                if ref.startswith('ref:'):
+                    ref_path = os.path.join(webull_path, '..', '.git', ref.split(' ')[1])
+                    with open(ref_path, 'r') as ref_file:
+                        return ref_file.read().strip()
+                else:
+                    return ref
+        return None
+    except Exception as e:
+        print(f"Error checking installed webull commit hash: {e}")
+        return None
+
+def get_webull_commit_hash_from_requirements(requirements_file):
+    with open(requirements_file, 'r') as file:
+        for line in file:
+            if line.startswith('-e git+https://github.com/NelsonDane/webull.git'):
+                match = re.search(r'@([a-f0-9]+)#egg=webull', line)
+                if match:
+                    return match.group(1)
+    return None
+
+def install_dependencies(requirements_file, exclude_webull=False):
+    with open(requirements_file, 'r') as file:
+        requirements = file.readlines()
+    
+    if exclude_webull:
+        requirements = [line for line in requirements if 'webull' not in line]
+    
+    for requirement in requirements:
+        subprocess.check_call([sys.executable, '-m', 'pip', 'install', requirement.strip()])
+
+def main():
+    requirements_file = 'requirements.txt'
+    installed_commit_hash = get_installed_webull_commit_hash()
+    required_commit_hash = get_webull_commit_hash_from_requirements(requirements_file)
+
+    print(f"Installed commit hash: {installed_commit_hash}")
+    print(f"Required commit hash: {required_commit_hash}")
+
+    if installed_commit_hash == required_commit_hash:
+        print("Webull is already installed and up-to-date.")
+        install_dependencies(requirements_file, exclude_webull=True)
+    else:
+        install_dependencies(requirements_file, exclude_webull=False)
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ requests==2.32.3
 robin-stocks==3.1.0
 schwab-api==0.4.3
 selenium==4.23.1
-setuptools==71.1.0
+setuptools==70.3.0
 tastytrade==8.0
 vanguard-api==0.1.9
 -e git+https://github.com/NelsonDane/webull.git@ef14ae63f9e1436fbea77fe864df54847cf2f730#egg=webull


### PR DESCRIPTION
'Pip install -r requirements.txt' installed Webull every time. This is an idea to bypass that functionality. Not sure why but this was periodically corrupting my webull library and I would have to uninstall/reinstall to get it working.

With the known bugs in Setuptools 71.X, can we please roll this back for now. 70.3.0 appears to be the most compatible for everyone.