### PR TITLE
Updated chaseAPI to allow for limit orders

### DIFF
--- a/chaseAPI.py
+++ b/chaseAPI.py
@@ -36,20 +36,24 @@ def chase_run(
     # Set the functions to be run
     _, second_command = command
 
+    # For each set of login info, i.e. seperate chase accounts
     for account in accounts:
+        # Start at index 1 and go to how many logins we have
         index = accounts.index(account) + 1
-        success = chase_init(
+        # Recieve the chase broker class object and the AllAccount object related to it
+        chase_details = chase_init(
             account=account,
             index=index,
             botObj=botObj,
             loop=loop,
         )
-        if success is not None:
-            orderObj.set_logged_in(success, "chase")
+        if chase_details is not None:
+            orderObj.set_logged_in(chase_details[0], "chase")
             if second_command == "_holdings":
-                chase_holdings(success, loop=loop)
+                chase_holdings(chase_details[0], chase_details[1], loop=loop)
+            # Only other option is _transaction
             else:
-                chase_transaction(success, orderObj, loop=loop)
+                chase_transaction(chase_details[0], chase_details[1], orderObj, loop=loop)
     return None
 
 
@@ -60,18 +64,38 @@ def get_account_id(account_connectors, value):
     return None
 
 
-def chase_init(account, index, botObj=None, loop=None):
+def chase_init(account: str, index: int, botObj=None, loop=None):
+    '''
+    Logs into chase. Checks for 2FA and gathers details on the chase accounts
+    
+    Args:
+        account (str): The chase username, password, last 4 of phone #, and possible debug flag, seperated by ':'.
+        index (int): The index of this chase account in a list of accounts.
+        botObj (Bot): The discord bot object if used.
+        loop (AbstractEventLoop): The event loop to be used
+    Raises:
+        Exception: Error logging in to Chase
+    Returns:
+        Brokerage object which represents the chase session and data.
+        AllAccounts object which holds account information.
+    '''
     # Log in to Chase account
     print("Logging in to Chase...")
+    # Create brokerage class object and call it chase
     chase_obj = Brokerage("Chase")
     name = f"Chase {index}"
     try:
+        # Split the login into into seperate items
         account = account.split(":")
+        # If the debug flag is present, use it, else set it to false
         debug = bool(account[3]) if len(account) == 4 else False
+        # Create a ChaseSession class object which automatically configures and opens a browser
         ch_session = session.ChaseSession(
             title=f"chase_{index}", headless=True, profile_path="./creds", debug=debug
         )
+        # Login to chase
         need_second = ch_session.login(account[0], account[1], account[2])
+        # If 2FA is present, ask for code
         if need_second:
             if botObj is None and loop is None:
                 ch_session.login_two(input("Enter code: "))
@@ -82,13 +106,19 @@ def chase_init(account, index, botObj=None, loop=None):
                 if sms_code is None:
                     raise Exception(f"Chase {index} code not received in time...", loop)
                 ch_session.login_two(sms_code)
+        # Create an AllAccounts class object using the current browser session. Holds information about all accounts
         all_accounts = ch_account.AllAccount(ch_session)
+        # Get the account IDs and store in a list. The IDs are different than account numbers.
         account_ids = list(all_accounts.account_connectors.keys())
         print("Logged in to Chase!")
+        # In the Chase Brokerage object, set the index of "Chase 1" to be its own empty array and append the chase session to the end of this array
         chase_obj.set_logged_in_object(name, ch_session)
+        # Create empty array to store account number masks (last 4 digits of each account number)
         print_accounts = []
         for acct in account_ids:
+            # Create an AccountDetails Object which organizes the information in the AllAccounts class object
             account = ch_account.AccountDetails(acct, all_accounts)
+            # Save account masks
             chase_obj.set_account_number(name, account.mask)
             chase_obj.set_account_totals(name, account.mask, account.account_value)
             print_accounts.append(account.mask)
@@ -98,21 +128,28 @@ def chase_init(account, index, botObj=None, loop=None):
         print(f"Error logging in to Chase: {e}")
         print(traceback.format_exc())
         return None
-    return chase_obj
+    return [chase_obj, all_accounts]
 
 
-def chase_holdings(chase_o: Brokerage, loop=None):
-    # Get holdings on each account
+def chase_holdings(chase_o: Brokerage, all_accounts: ch_account.AllAccount, loop=None):
+    '''
+    Get the holdings of chase account
+
+    Args:
+        chase_o (Brokerage): Brokerage object associated with the current session.
+        all_accounts (AllAccount): AllAccount object that holds account information.
+        loop (AbstractEventLoop): The event loop to be used if present.
+    '''
+    # Get holdings on each account. This loop only ever runs once.
     for key in chase_o.get_account_numbers():
         try:
+            # Retrieve account masks and iterate through them
             for h, account in enumerate(chase_o.get_account_numbers(key)):
-                obj: session.ChaseSession = chase_o.get_logged_in_objects(key)
-                if h == 0:
-                    all_accounts = ch_account.AllAccount(obj)
-                    if all_accounts is None:
-                        raise Exception("Error getting account details")
+                # Retrieve the chase session
+                ch_session: session.ChaseSession = chase_o.get_logged_in_objects(key)
+                # Get the account ID accociated with mask
                 account_id = get_account_id(all_accounts.account_connectors, account)
-                data = symbols.SymbolHoldings(account_id, obj)
+                data = symbols.SymbolHoldings(account_id, ch_session)
                 success = data.get_holdings()
                 if success:
                     for i, _ in enumerate(data.positions):
@@ -145,37 +182,71 @@ def chase_holdings(chase_o: Brokerage, loop=None):
                                 qty = data.positions[i]["tradedUnitQuantity"]
                             chase_o.set_holdings(key, account, sym, qty, current_price)
         except Exception as e:
-            obj.close_browser()
+            ch_session.close_browser()
             printAndDiscord(f"{key} {account}: Error getting holdings: {e}", loop)
             print(traceback.format_exc())
             continue
         printHoldings(chase_o, loop)
-    obj.close_browser()
+    ch_session.close_browser()
 
 
-def chase_transaction(chase_o: Brokerage, orderObj: stockOrder, loop=None):
+def chase_transaction(chase_obj: Brokerage, all_accounts: ch_account.AllAccount, orderObj: stockOrder, loop=None):
+    '''
+    Executes transactions on all accounts.
+
+    Args: 
+        chase_obj (Brokerage): The brokerage class object related to the chase session.
+        all_accounts (AllAccount): AllAccount object that holds account information.
+        orderObj (stockOrder): The order(s) to be executed.
+        loop (AbstractEventLoop): The event loop to be used if present.
+    Returns:
+        None
+    '''
     print()
     print("==============================")
     print("Chase")
     print("==============================")
     print()
-    account_id = None
+    
     # Buy on each account
-    for s in orderObj.get_stocks():
-        for key in chase_o.get_account_numbers():
+    for ticker in orderObj.get_stocks():
+        
+        # This loop should only run once, but it provides easy access to the chase session by using key to get it back from 
+        # the chase_obj via get_logged_in_objects
+        for key in chase_obj.get_account_numbers():
+            
+            account_ids = list(all_accounts.account_connectors.keys())
+            # Load the chase session
+            ch_session: session.ChaseSession = chase_obj.get_logged_in_objects(key)
+            
+            # Get the ask price and determine whether to use MARKET or LIMIT order
+            # Enter an account number, the chase session, and the stock ticker
+            symbol_quote = symbols.SymbolQuote(account_id=account_ids[0], session=ch_session, symbol=ticker)
+            
+            # Declare type for later
+            price_type = None
+            
+            # Determine type
+            if symbol_quote.ask_price < 1 and orderObj.get_action().capitalize() == "Buy":
+                price_type = order.PriceType.LIMIT
+            else:
+                price_type = order.PriceType.MARKET
+            
+            # Set the price difference
+            difference_price = 0.01 if float(symbol_quote.ask_price) > 0.1 else 0.0001
+            
+            
             printAndDiscord(
-                f"{key} {orderObj.get_action()}ing {orderObj.get_amount()} {s} @ {orderObj.get_price()}",
+                f"{key} {orderObj.get_action()}ing {orderObj.get_amount()} {ticker} @ {price_type.value}",
                 loop,
             )
             try:
-                print(chase_o.get_account_numbers())
-                for account in chase_o.get_account_numbers(key):
-                    obj: session.ChaseSession = chase_o.get_logged_in_objects(key)
-                    if account_id is None:
-                        all_accounts = ch_account.AllAccount(obj)
-                        if all_accounts is None:
-                            raise Exception("Error getting account details")
-                    account_id = get_account_id(
+                print(chase_obj.get_account_numbers())
+                # For each account number "mask" attached to "Chase_#" complete the order
+                for account in chase_obj.get_account_numbers(key):
+                    
+                    
+                    target_account_id = get_account_id(
                         all_accounts.account_connectors, account
                     )
                     # If DRY is True, don't actually make the transaction
@@ -183,20 +254,23 @@ def chase_transaction(chase_o: Brokerage, orderObj: stockOrder, loop=None):
                         printAndDiscord(
                             "Running in DRY mode. No transactions will be made.", loop
                         )
-                    price_type = order.PriceType.MARKET
+                        
                     if orderObj.get_action().capitalize() == "Buy":
                         order_type = order.OrderSide.BUY
                     else:
+                        # Reset to market for selling
+                        price_type = order.PriceType.MARKET
                         order_type = order.OrderSide.SELL
-                    chase_order = order.Order(obj)
+                    chase_order = order.Order(ch_session)
                     messages = chase_order.place_order(
-                        account_id=account_id,
+                        account_id=target_account_id,
                         quantity=int(orderObj.get_amount()),
                         price_type=price_type,
-                        symbol=s,
+                        symbol=ticker,
                         duration=order.Duration.DAY,
                         order_type=order_type,
                         dry_run=orderObj.get_dry(),
+                        limit_price=symbol_quote.ask_price + difference_price
                     )
                     print("The order verification produced the following messages: ")
                     if orderObj.get_dry():
@@ -250,7 +324,7 @@ def chase_transaction(chase_o: Brokerage, orderObj: stockOrder, loop=None):
                 printAndDiscord(f"{key} {account}: Error submitting order: {e}", loop)
                 print(traceback.format_exc())
                 continue
-    obj.close_browser()
+    ch_session.close_browser()
     printAndDiscord(
         "All Chase transactions complete",
         loop,


### PR DESCRIPTION
Made changes to the chaseAPI functions to reduce repetition, reuse data, and deciding when you use LIMIT buys. 

Repetition changes and reusing data:
The chase_holdings and chase_transaction functions both loaded urls to get the users account data when this step was already done in the init function. I changed the function parameters to accept the AllAccounts class object created in chase_init so that the holdings and transaction functions will take less time to complete.

LIMIT buys:
Using the SymbolQuote function, the transaction function will now obtain the ask price for the ticker and if it is less than $1, it will place a limit order. Else, it will use market order.

Comments:
Created lots of comments explaining the code flow and purpose. 

