### PR TITLE
Check Python Version and Local Up-to-Date

### DIFF
--- a/autoRSA.py
+++ b/autoRSA.py
@@ -7,6 +7,13 @@ import os
 import sys
 import traceback
 
+# Check Python version (minimum 3.10)
+print("Python version:", sys.version)
+if sys.version_info < (3, 10):
+    print("Python 3.10 or newer is required")
+    sys.exit(1)
+print()
+
 try:
     import discord
     from discord.ext import commands
@@ -227,12 +234,6 @@ def argParser(args: list) -> stockOrder:
 
 
 if __name__ == "__main__":
-    # Check Python version (minimum 3.10)
-    print("Python version:", sys.version)
-    if sys.version_info < (3, 10):
-        print("Python 3.10 or newer is required")
-        sys.exit(1)
-    print()
     # Determine if ran from command line
     if len(sys.argv) == 1:  # If no arguments, do nothing
         print("No arguments given, see README for usage")

--- a/autoRSA.py
+++ b/autoRSA.py
@@ -227,6 +227,12 @@ def argParser(args: list) -> stockOrder:
 
 
 if __name__ == "__main__":
+    # Check Python version (minimum 3.10)
+    print("Python version:", sys.version)
+    if sys.version_info < (3, 10):
+        print("Python 3.10 or newer is required")
+        sys.exit(1)
+    print()
     # Determine if ran from command line
     if len(sys.argv) == 1:  # If no arguments, do nothing
         print("No arguments given, see README for usage")

--- a/autoRSA.py
+++ b/autoRSA.py
@@ -10,7 +10,7 @@ import traceback
 # Check Python version (minimum 3.10)
 print("Python version:", sys.version)
 if sys.version_info < (3, 10):
-    print("Python 3.10 or newer is required")
+    print("ERROR: Python 3.10 or newer is required")
     sys.exit(1)
 print()
 

--- a/helperAPI.py
+++ b/helperAPI.py
@@ -344,6 +344,7 @@ def is_up_to_date(remote, branch):
 
     # Check if local branch is up to date with ls-remote
     up_to_date = False
+    remote_hash = ""
     try:
         g = git.cmd.Git()
         ls_remote = g.ls_remote(remote, branch)

--- a/helperAPI.py
+++ b/helperAPI.py
@@ -384,18 +384,16 @@ def updater():
         # Always create main branch
         repo.create_head("main", repo.remotes.origin.refs.main)
         repo.heads.main.set_tracking_branch(repo.remotes.origin.refs.main)
-        # If downloaded from other branch, zip has branch name
-        current_dir = Path.cwd()
-        if current_dir.name != "auto-rsa-main":
-            branch = str.replace(current_dir.name, "auto-rsa-", "")
+        repo.heads.main.checkout(True)
+        # When downloaded as zip, it contains the branch name
+        branch = str(Path.cwd().name).split("-")[-1]
+        if branch != "main":
             try:
                 repo.create_head(branch, repo.remotes.origin.refs[branch])
                 repo.heads[branch].set_tracking_branch(repo.remotes.origin.refs[branch])
                 repo.heads[branch].checkout(True)
             except:
-                print(f"No branch {branch} found, using main")
-        else:
-            repo.heads.main.checkout(True)
+                print(f"No branch named {branch} found, using main")
         print(f"Cloned repo from {repo.active_branch}")
     if repo.is_dirty():
         # Print warning and let users take care of changes themselves

--- a/helperAPI.py
+++ b/helperAPI.py
@@ -345,12 +345,12 @@ def is_up_to_date(remote, branch):
     # Check if local branch is up to date with ls-remote
     up_to_date = False
     remote_hash = ""
+    local_commit = git.Repo(".").head.commit.hexsha
     try:
         g = git.cmd.Git()
         ls_remote = g.ls_remote(remote, branch)
-        remote_hash = ls_remote.split("\t")[0]
-        local_commit = git.Repo(".").head.commit.hexsha
-        if str(local_commit) == str(remote_hash):
+        remote_hash = str(ls_remote.split("\t")[0])
+        if local_commit == remote_hash:
             up_to_date = True
             print(f"You are up to date with {remote}/{branch}")
     except Exception as e:

--- a/helperAPI.py
+++ b/helperAPI.py
@@ -338,7 +338,7 @@ class ThreadHandler:
         return self.queue.get()
 
 
-def isUpToDate(remote, branch):
+def is_up_to_date(remote, branch):
     # Assume succeeded in updater()
     import git
 
@@ -401,7 +401,7 @@ def updater():
             "UPDATE ERROR: Conflicting changes found. Please commit, stash, or remove your changes before updating."
         )
         print(f"Using commit {str(repo.head.commit)[:7]}")
-        isUpToDate("origin", repo.active_branch)
+        is_up_to_date("origin", repo.active_branch)
         print()
         return
     if not repo.bare:
@@ -415,7 +415,7 @@ def updater():
             print()
             return
     print(f"Update complete! Now using commit {str(repo.head.commit)[:7]}")
-    isUpToDate("origin", repo.active_branch)
+    is_up_to_date("origin", repo.active_branch)
     print()
     return
 

--- a/helperAPI.py
+++ b/helperAPI.py
@@ -393,7 +393,7 @@ def updater():
                 repo.create_head(branch, repo.remotes.origin.refs[branch])
                 repo.heads[branch].set_tracking_branch(repo.remotes.origin.refs[branch])
                 repo.heads[branch].checkout(True)
-            except:
+            except Exception:
                 print(f"No branch named {branch} found, using main")
         print(f"Cloned repo from {repo.active_branch}")
     if repo.is_dirty():

--- a/helperAPI.py
+++ b/helperAPI.py
@@ -338,23 +338,45 @@ class ThreadHandler:
         return self.queue.get()
 
 
+def isUpToDate(remote, branch):
+    # Assume succeeded in updater()
+    import git
+    # Check if local branch is up to date with ls-remote
+    up_to_date = False
+    try:
+        g = git.cmd.Git()
+        ls_remote = g.ls_remote(remote, branch)
+        remote_hash = ls_remote.split("\t")[0]
+        local_commit = git.Repo(".").head.commit.hexsha
+        if str(local_commit) == str(remote_hash):
+            up_to_date = True
+            print(f"You are up to date with {remote}/{branch}")
+    except Exception as e:
+        print(f"Error running ls-remote: {e}")
+    if not up_to_date:
+        if remote_hash == "":
+            remote_hash = "NOT FOUND"
+        print(
+            f"WARNING: YOU ARE OUT OF DATE. Please run 'git pull {remote} {branch}' to update. Local hash: {local_commit}, Remote hash: {remote_hash}"
+        )
+    return up_to_date
+
 def updater():
     # Check if git is installed
     try:
         import git
-        from git import Repo
     except ImportError:
         print(
             "UPDATE ERROR: Git is not installed. Please install Git and then run pip install -r requirements.txt"
         )
         print()
         return
-    print("Starting auto update...")
+    print("Starting Git auto update...")
     try:
-        repo = Repo(".")
+        repo = git.Repo(".")
     except git.exc.InvalidGitRepositoryError:
         # If downloaded as zip, repo won't exist, so create it
-        repo = Repo.init(".")
+        repo = git.Repo.init(".")
         repo.create_remote("origin", "https://github.com/NelsonDane/auto-rsa")
         repo.remotes.origin.fetch()
         # Always create main branch
@@ -379,6 +401,7 @@ def updater():
             "UPDATE ERROR: Conflicting changes found. Please commit, stash, or remove your changes before updating."
         )
         print(f"Using commit {str(repo.head.commit)[:7]}")
+        isUpToDate("origin", repo.active_branch)
         print()
         return
     if not repo.bare:
@@ -392,15 +415,13 @@ def updater():
             print()
             return
     print(f"Update complete! Now using commit {str(repo.head.commit)[:7]}")
-    print(
-        f"Check if you're up to date here: https://github.com/NelsonDane/auto-rsa/commits/{repo.active_branch}"
-    )
+    isUpToDate("origin", repo.active_branch)
     print()
     return
 
 
 def check_package_versions():
-    print("Checking package versions...")
+    print("Checking Python pip package versions...")
     # Check if pip packages are up to date
     required_packages = []
     required_repos = []


### PR DESCRIPTION
Creates a minimum Python version limit at 3.10 (was a soft limit before but never enforced).

Checks the newest commit on GitHub using `git ls-remote <origin> <branch>`, then compares the local repo's newest hash. This way a large WARNING can be printed so people (and troubleshooters) will easily know if they're out of date with the origin.

Also fixes the case where a repository downloaded as a zip was unable to initialize on a branch other than main not getting set to main in the exception catch.