### PR TITLE
Robinhood login

### DIFF
--- a/robinhoodAPI.py
+++ b/robinhoodAPI.py
@@ -38,7 +38,7 @@ def robinhood_init(ROBINHOOD_EXTERNAL=None):
                 mfa_code=(
                     None if account[2].upper() == "NA" else pyotp.TOTP(account[2]).now()
                 ),
-                store_session=True,
+                store_session=False,
             )
             rh_obj.set_logged_in_object(name, rh)
             # Load all accounts

--- a/robinhoodAPI.py
+++ b/robinhoodAPI.py
@@ -38,7 +38,7 @@ def robinhood_init(ROBINHOOD_EXTERNAL=None):
                 mfa_code=(
                     None if account[2].upper() == "NA" else pyotp.TOTP(account[2]).now()
                 ),
-                store_session=False,
+                store_session=True,
             )
             rh_obj.set_logged_in_object(name, rh)
             # Load all accounts

--- a/robinhoodAPI.py
+++ b/robinhoodAPI.py
@@ -34,10 +34,11 @@ def robinhood_init(ROBINHOOD_EXTERNAL=None):
             rh.login(
                 username=account[0],
                 password=account[1],
+                expiresIn=86400 * 30,
                 mfa_code=(
                     None if account[2].upper() == "NA" else pyotp.TOTP(account[2]).now()
                 ),
-                store_session=False,
+                store_session=True,
             )
             rh_obj.set_logged_in_object(name, rh)
             # Load all accounts


### PR DESCRIPTION
Made changes to robinhood login: 
- Enabled store_session so that the session is saved to a pickle file for future logins
- Set expiresIn to 30 days instead of the the default 1 day

This fixes the issue of needing to enter a 2fa code every time the bot restarts. It worked when I tested.