### PR TITLE
robinhooodAPI 'holdings' not returning all accounts if multiple

### DIFF
--- a/robinhoodAPI.py
+++ b/robinhoodAPI.py
@@ -30,8 +30,6 @@ def robinhood_init(ROBINHOOD_EXTERNAL=None):
         index = RH.index(account) + 1
         name = f"Robinhood {index}"
         try:
-                        account = account.split(":")
-
             account_details = account.split(":") # Specifies credentials to be stored in 'Brokerage' class 
             username = account_details[0]
             password = account_details[1]


### PR DESCRIPTION
I have several Robinhood accounts that I am using this script for, and I noticed that '!rsa holdings robinhood' was only returning the holdings for the final account. It looks like the initial accounts were logged out when the script tried to pull in position data. 

I'm not sure if this fix is ideal, but I updated the init() function to return the login credentials with rh_obj so that they could be retrieved in the holdings function to iterate through accounts and save the position info. For this, I needed to also update the 'Brokerage' class in helper.API to handle the credentials. 

Anyways, like I said I'm not sure this is the best solution but interested to see what you think.