### PR TITLE
Fix Multiple Robinhood Accounts and Save Cookies Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Required `.env` variables:
 
 Configuring 2fa can be tricky, so follow this [guide](guides/robinhoodSetup.md).
 
+Note: Robinhood saves token cookies in the `creds` folder. These take precedence over the username/password set in the `.env` file. If you want to change accounts, you will need to delete the cookies in the `creds` folder for it to update.
+
 ### Schwab
 Made using the [schwab-api](https://github.com/itsjafer/schwab-api). Go give them a ⭐
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,8 @@ public-invest-api==1.0.4
 pyotp==2.9.0
 python-dotenv==1.0.1
 requests==2.32.3
-robin-stocks==3.1.0
+# robin-stocks==3.1.0
+-e git+https://github.com/NelsonDane/robin_stocks.git@2387113072bb26bcc1bd3fed8b4d74b0afb19f29#egg=robin-stocks
 schwab-api==0.4.3
 selenium-stealth==1.0.6
 setuptools==73.0.1

--- a/robinhoodAPI.py
+++ b/robinhoodAPI.py
@@ -33,6 +33,7 @@ def robinhood_init(ROBINHOOD_EXTERNAL=None):
         else ROBINHOOD_EXTERNAL.strip().split(",")
     )
     # Log in to Robinhood account
+    all_account_numbers = []
     for account in RH:
         index = RH.index(account) + 1
         name = f"Robinhood {index}"
@@ -54,6 +55,9 @@ def robinhood_init(ROBINHOOD_EXTERNAL=None):
             # Load all accounts
             all_accounts = rh.account.load_account_profile(dataType="results")
             for a in all_accounts:
+                if a["account_number"] in all_account_numbers:
+                    continue
+                all_account_numbers.append(a["account_number"])
                 rh_obj.set_account_number(name, a["account_number"])
                 rh_obj.set_account_totals(
                     name,


### PR DESCRIPTION
See `robin_stocks` PR: https://github.com/jmfernandes/robin_stocks/pull/490

Saves Robinhood cookies to `./creds/`, and adds a `login_with_cache` function to refresh the accounts. Previously, the accounts would overwrite each other (an issue with the `robin_stocks` library, but one way too big to debug right now) which would occur in the last account being the only working one. The function uses the saved cookies to avoid hitting the Robinhood API, and is more of a way to tell the API to "switch" to that account/cache.

Since Joint accounts show up under both logins, don't add a duplicate when it's found under multiple logins.

Depends on and implements: https://github.com/NelsonDane/auto-rsa/pull/332