### PR TITLE
Undetected Chrome driver support

### DIFF
--- a/helperAPI.py
+++ b/helperAPI.py
@@ -528,17 +528,10 @@ def getDriver(DOCKER=False):
     # Init webdriver options
     try:
         options = uc.ChromeOptions()
-        options.add_argument("--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15")
         options.add_argument("--start-maximized")
         options.add_argument("--disable-blink-features=AutomationControlled")
         options.add_argument("--disable-extensions")
         options.add_argument("--disable-notifications")
-        prefs = {
-            "profile.default_content_setting_values.popups": 1,
-            "profile.default_content_setting_values.redirects": 1,
-            "profile.default_content_setting_values.automatic_downloads": 1,
-        }
-        options.add_experimental_option("prefs", prefs)
         if DOCKER:
             # Special Docker options
             options.add_argument("--disable-dev-shm-usage")

--- a/helperAPI.py
+++ b/helperAPI.py
@@ -15,12 +15,12 @@ from time import sleep
 
 import pkg_resources
 import requests
+import undetected_chromedriver as uc
 from discord.ext import commands
 from dotenv import load_dotenv
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service as ChromiumService
 from selenium_stealth import stealth
-import undetected_chromedriver as uc
 
 load_dotenv()
 DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")

--- a/helperAPI.py
+++ b/helperAPI.py
@@ -20,6 +20,7 @@ from dotenv import load_dotenv
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service as ChromiumService
 from selenium_stealth import stealth
+import undetected_chromedriver as uc
 
 load_dotenv()
 DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
@@ -525,13 +526,18 @@ def check_if_page_loaded(driver):
 def getDriver(DOCKER=False):
     # Init webdriver options
     try:
-        options = webdriver.ChromeOptions()
-        options.add_argument("start-maximized")
-        options.add_experimental_option("excludeSwitches", ["enable-automation"])
-        options.add_experimental_option("useAutomationExtension", False)
+        options = uc.ChromeOptions()
+        options.add_argument("--user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15")
+        options.add_argument("--start-maximized")
         options.add_argument("--disable-blink-features=AutomationControlled")
         options.add_argument("--disable-extensions")
         options.add_argument("--disable-notifications")
+        prefs = {
+            "profile.default_content_setting_values.popups": 1,
+            "profile.default_content_setting_values.redirects": 1,
+            "profile.default_content_setting_values.automatic_downloads": 1,
+        }
+        options.add_experimental_option("prefs", prefs)
         if DOCKER:
             # Special Docker options
             options.add_argument("--disable-dev-shm-usage")
@@ -539,7 +545,8 @@ def getDriver(DOCKER=False):
             options.add_argument("--disable-gpu")
         if DOCKER or HEADLESS:
             options.add_argument("--headless")
-        driver = webdriver.Chrome(
+        driver = uc.Chrome(
+            use_subprocess=True,
             options=options,
             # Docker uses specific chromedriver installed via apt
             service=ChromiumService("/usr/bin/chromedriver") if DOCKER else None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@ requests==2.32.3
 -e git+https://github.com/NelsonDane/robin_stocks.git@2387113072bb26bcc1bd3fed8b4d74b0afb19f29#egg=robin-stocks
 schwab-api==0.4.3
 selenium-stealth==1.0.6
-undetected-chromedriver==3.5.5
 setuptools==75.0.0
 tastytrade==8.3
+undetected-chromedriver==3.5.5
 vanguard-api==0.2.5
 -e git+https://github.com/NelsonDane/webull.git@ef14ae63f9e1436fbea77fe864df54847cf2f730#egg=webull

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ requests==2.32.3
 -e git+https://github.com/NelsonDane/robin_stocks.git@2387113072bb26bcc1bd3fed8b4d74b0afb19f29#egg=robin-stocks
 schwab-api==0.4.3
 selenium-stealth==1.0.6
+undetected-chromedriver==3.5.5
 setuptools==75.0.0
 tastytrade==8.3
 vanguard-api==0.2.5


### PR DESCRIPTION
This should be able to now use Undetected Chrome driver instead of plain selenium in order to better stop sites from detecting bot activity and now bypass certain cloudflare bot detections. I was running into a lot of issues with SoFI and their cloudflare Human Verification. This bypassed that issue and should for others.