### PR TITLE
Fix printing message if Tornado not found.

### DIFF
--- a/tornadoAPI.py
+++ b/tornadoAPI.py
@@ -32,7 +32,7 @@ def tornado_init(TORNADO_EXTERNAL=None, DOCKER=False, loop=None):
     load_dotenv()
 
     if not os.getenv("TORNADO") and TORNADO_EXTERNAL is None:
-        printAndDiscord("Tornado environment variable not found.", loop)
+        print("Tornado not found, skipping...")
         return None
 
     if TORNADO_EXTERNAL is None:


### PR DESCRIPTION
The Tornado API prints a message that is not found in Discord if not configured, which makes it a little bit annoying and affects the output. Maybe printing it in the console like other brokerages would be a better idea.