### PR TITLE
fix playwright stealth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ setuptools==75.1.0
 tastytrade==8.3
 vanguard-api==0.2.5
 -e git+https://github.com/NelsonDane/webull.git@ef14ae63f9e1436fbea77fe864df54847cf2f730#egg=webull
+#playwright stealth from pypi seems abandoned
+-e git+https://github.com/MaxxRK/playwright_stealth.git@a6688bb792395f182d22dff3e330400bb0df1eca#egg=playwright_stealth

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,10 @@ discord.py==2.4.0
 fennel-invest-api==1.1.0
 firstrade==0.0.30
 GitPython==3.1.43
-public-invest-api==1.0.4
 pandas<2.2.3
+# playwright stealth from pypi seems abandoned
+-e git+https://github.com/MaxxRK/playwright_stealth.git@a6688bb792395f182d22dff3e330400bb0df1eca#egg=playwright_stealth
+public-invest-api==1.0.4
 pyotp==2.9.0
 python-dotenv==1.0.1
 requests==2.32.3
@@ -18,5 +20,3 @@ setuptools==75.1.0
 tastytrade==8.3
 vanguard-api==0.2.5
 -e git+https://github.com/NelsonDane/webull.git@ef14ae63f9e1436fbea77fe864df54847cf2f730#egg=webull
-#playwright stealth from pypi seems abandoned
--e git+https://github.com/MaxxRK/playwright_stealth.git@a6688bb792395f182d22dff3e330400bb0df1eca#egg=playwright_stealth


### PR DESCRIPTION
- Playwright stealth has not had any contributions since September of last year. 
- It was causing Vanguards login page not to load.
- I have updated the package to work better. 
- I have tested it with the three playwright brokers. (Chase, Schwab and Vanguard)
- I have submitted a pull request to the author. If it is not merged within a couple of weeks, I will create a new package on pypi that we can use.
- I put a requirement in this package for playwright==1.47.0. When I tried testing it on 1.44.0 it did not seem to work correctly. I want the playwright version to stay the same until it can be tested with playwright stealth each time.