### PR TITLE
FidelityAPI: Add exact match for limit price box selection

### DIFF
--- a/fidelityAPI.py
+++ b/fidelityAPI.py
@@ -661,7 +661,7 @@ def fidelity_run(
         fidelityobj = fidelity_init(
             account=account,
             name=name,
-            headless=False,
+            headless=headless,
             botObj=botObj,
             loop=loop,
         )


### PR DESCRIPTION
FidelityAPI
This should fix the error encountered by PapaY
Tested with buying 1 stock on all accounts