### PR TITLE
Fix WellsFargo not showing IRA accounts

### DIFF
--- a/wellsfargoAPI.py
+++ b/wellsfargoAPI.py
@@ -121,16 +121,16 @@ def wellsfargo_init(botObj, WELLSFARGO_EXTERNAL=None, DOCKER=False, loop=None):
 
             # TODO: This will not show accounts that do not have settled cash funds
             account_blocks = driver.find_elements(
-                By.CSS_SELECTOR, 'li[data-testid="WELLSTRADE"]'
+                By.CSS_SELECTOR, 'li[data-testid^="WELLSTRADE"]'
             )
             for account_block in account_blocks:
                 masked_number_element = account_block.find_element(
-                    By.CSS_SELECTOR, '[data-testid="WELLSTRADE-masked-number"]'
+                    By.CSS_SELECTOR, '[data-testid$="-masked-number"]'
                 )
                 masked_number_text = masked_number_element.text.replace(".", "*")
                 WELLSFARGO_obj.set_account_number(name, masked_number_text)
                 balance_element = account_block.find_element(
-                    By.CSS_SELECTOR, '[data-testid="WELLSTRADE-balance"]'
+                    By.CSS_SELECTOR, '[data-testid$="-balance"]'
                 )
                 balance = float(balance_element.text.replace("$", ""))
                 WELLSFARGO_obj.set_account_totals(name, masked_number_text, balance)


### PR DESCRIPTION
This worked for me for viewing holdings and successfully displayed all accounts. I have not been able to test buying/selling as the market is closed.

Changed lines 124, 128, 133

'li[data-testid="WELLSTRADE"]'
to
'li[data-testid^="WELLSTRADE"]'

'[data-testid="WELLSTRADE-masked-number"]
to
'[data-testid$="-masked-number"

'[data-testid="WELLSTRADE-balance"]'
to
'[data-testid$="-balance"]'