### PR TITLE
WebullAPI.py Margin Acct Protections

### DIFF
--- a/webullAPI.py
+++ b/webullAPI.py
@@ -230,7 +230,7 @@ def check_day_trades(ac):
             print(maskString(ac["accountNumber"])+' Maximum day trades reached; skipping account.')
             return True
         else:
-            print(f"You can still make {3 - total_day_trades} day trades.")
+            print(maskString(ac["accountNumber"])+f" You can still make {3 - total_day_trades} day trades.")
             return False
     else:
         return False


### PR DESCRIPTION
Adding functionality to check for Webull margin account day trades and prevent from purchasing if already at 3.

Could be improved by looking at how many tickers were entered for trading.