### PR TITLE
bump playwright stealth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ fennel-invest-api==1.1.1
 firstrade==0.0.30
 GitPython==3.1.43
 # playwright stealth from pypi seems abandoned
--e git+https://github.com/MaxxRK/playwright_stealth.git@a6688bb792395f182d22dff3e330400bb0df1eca#egg=playwright_stealth
+-e git+https://github.com/MaxxRK/playwright_stealth.git@f87d7c3d67134ad6def356dce6545c2f42662dfb#egg=playwright_stealth
 public-invest-api==1.0.4
 pyotp==2.9.0
 python-dotenv==1.0.1


### PR DESCRIPTION
Update playwright stealth to support playwright 1.48.0. From preliminary testing this will successfully build in python 3.13 and python 3.13-slim in the docker image.

It also works for 3.12.

Users will need to run `playwright install firefox` after update.