### PR TITLE
Update sofiAPI.py

### DIFF
--- a/sofiAPI.py
+++ b/sofiAPI.py
@@ -486,7 +486,7 @@ async def sofi_buy(browser, symbol, quantity, discord_loop, dry_mode=False):
         if stock_price is None:
             raise Exception(f"Failed to retrieve stock price for {symbol}")
 
-        limit_price = round(stock_price + 0.01, 2)
+        limit_price = stock_price
 
         # Step 3: Fetch all funded accounts and their buying power
         accounts = await fetch_funded_accounts(cookies)


### PR DESCRIPTION
Fixed issue when buying stock lets say, price is .12 the previous code would have put a buy order with the limit price .13 
Now, it should just keep the market price without rounding for the buy order so it will put .12 for the buy order limit price