### PR TITLE
fix ft holdings

### DIFF
--- a/firstradeAPI.py
+++ b/firstradeAPI.py
@@ -10,6 +10,7 @@ from time import sleep
 from dotenv import load_dotenv
 from firstrade import account as ft_account
 from firstrade import order, symbols
+from firstrade.exceptions import QuoteRequestError
 
 from helperAPI import (
     Brokerage,
@@ -95,12 +96,18 @@ def firstrade_holdings(firstrade_o: Brokerage, loop=None):
             try:
                 data = ft_account.FTAccountData(obj).get_positions(account=account)
                 for item in data["items"]:
+                    symbol = item["symbol"]
+                    try:
+                        quote = symbols.SymbolQuote(obj, account, symbol)
+                        price = quote.last
+                    except QuoteRequestError:
+                        price = 0
                     firstrade_o.set_holdings(
                         key,
                         account,
-                        item.get("symbol") or "Unknown",
+                        symbol,
                         item["quantity"],
-                        item["market_value"],
+                        price,
                     )
             except Exception as e:
                 printAndDiscord(f"{key} {account}: Error getting holdings: {e}", loop)


### PR DESCRIPTION
Holdings on firstrade was returning inaccurate values

It was pulling the total value of the security in the account. I.E.
5 x INTC @ 100.00 Total: 500 when intc is 10.00 per. (This is not accurate just an example)

Firstrade after this pr will always get a symbol quote so it can get an accurate quote for just one stock before adding it to the brokerage object.