### PR TITLE
Total holdings across brokers

### DIFF
--- a/autoRSA.py
+++ b/autoRSA.py
@@ -116,6 +116,7 @@ def nicknames(broker):
 # broker name + type of function
 def fun_run(orderObj: stockOrder, command, botObj=None, loop=None):
     if command in [("_init", "_holdings"), ("_init", "_transaction")]:
+        totalValue = 0
         for broker in orderObj.get_brokers():
             if broker in orderObj.get_notbrokers():
                 continue
@@ -195,26 +196,19 @@ def fun_run(orderObj: stockOrder, command, botObj=None, loop=None):
                             f"All {broker.capitalize()} transactions complete",
                             loop,
                         )
+                # Add to total sum
+                totalValue += sum(
+                    account["total"] for account in orderObj.get_logged_in(broker).get_account_totals().values()
+                )
             except Exception as ex:
                 print(traceback.format_exc())
                 print(f"Error in {fun_name} with {broker}: {ex}")
                 print(orderObj)
             print()
-            
-            # Print out the total holdings across all brokers
-            if "_holdings" in command:
-                totalValue = 0
-                for broker in set(orderObj.get_brokers()) - set(orderObj.get_notbrokers()):
-                    try: 
-                        broker = nicknames(broker)
-                        logged_in_broker = orderObj.get_logged_in(broker)
-                        if logged_in_broker is None:
-                            continue
-                        totalValue += sum(account["total"] for account in logged_in_broker.get_account_totals().values())
-                    except Exception as ex:
-                        print(f"Error getting account totals with {broker}: {ex}")   
-                printAndDiscord(f"Total: ${format(totalValue,'0.2f')}", loop)
-        
+
+        # Print final total value and closing message
+        if "_holdings" in command:
+            printAndDiscord(f"Total Value of All Accounts: ${format(totalValue,'0.2f')}", loop)
         printAndDiscord("All commands complete in all brokers", loop)
     else:
         print(f"Error: {command} is not a valid command")

--- a/autoRSA.py
+++ b/autoRSA.py
@@ -208,7 +208,7 @@ def fun_run(orderObj: stockOrder, command, botObj=None, loop=None):
 
         # Print final total value and closing message
         if "_holdings" in command:
-            printAndDiscord(f"Total Value of All Accounts: ${format(totalValue,'0.2f')}", loop)
+            printAndDiscord(f"Total Value of All Accounts: ${format(totalValue, '0.2f')}", loop)
         printAndDiscord("All commands complete in all brokers", loop)
     else:
         print(f"Error: {command} is not a valid command")

--- a/autoRSA.py
+++ b/autoRSA.py
@@ -200,6 +200,21 @@ def fun_run(orderObj: stockOrder, command, botObj=None, loop=None):
                 print(f"Error in {fun_name} with {broker}: {ex}")
                 print(orderObj)
             print()
+            
+            # Print out the total holdings across all brokers
+            if "_holdings" in command:
+                totalValue = 0
+                for broker in set(orderObj.get_brokers()) - set(orderObj.get_notbrokers()):
+                    try: 
+                        broker = nicknames(broker)
+                        logged_in_broker = orderObj.get_logged_in(broker)
+                        if logged_in_broker is None:
+                            continue
+                        totalValue += sum(account["total"] for account in logged_in_broker.get_account_totals().values())
+                    except Exception as ex:
+                        print(f"Error getting account totals with {broker}: {ex}")   
+                printAndDiscord(f"Total: ${format(totalValue,'0.2f')}", loop)
+        
         printAndDiscord("All commands complete in all brokers", loop)
     else:
         print(f"Error: {command} is not a valid command")

--- a/helperAPI.py
+++ b/helperAPI.py
@@ -256,9 +256,8 @@ class Brokerage:
         if parent_name not in self.__account_totals:
             self.__account_totals[parent_name] = {}
         self.__account_totals[parent_name][account_name] = round(float(total), 2)
-        self.__account_totals[parent_name]["total"] = 0
         self.__account_totals[parent_name]["total"] = sum(
-            self.__account_totals[parent_name].values()
+            value for key, value in self.__account_totals[parent_name].items() if key != "total"
         )
 
     def set_account_type(self, parent_name: str, account_name: str, account_type: str):

--- a/helperAPI.py
+++ b/helperAPI.py
@@ -256,6 +256,7 @@ class Brokerage:
         if parent_name not in self.__account_totals:
             self.__account_totals[parent_name] = {}
         self.__account_totals[parent_name][account_name] = round(float(total), 2)
+        self.__account_totals[parent_name]["total"] = 0
         self.__account_totals[parent_name]["total"] = sum(
             self.__account_totals[parent_name].values()
         )


### PR DESCRIPTION
- Fixed bug in the `set_account_totals` function where "total" field was incorrectly included in sum calculation.
- Added new feature: Holdings command now prints out total holdings across all brokerages.