### PR TITLE
Bypass process_commands to allow bot messages

### DIFF
--- a/autoRSA.py
+++ b/autoRSA.py
@@ -234,7 +234,7 @@ def argParser(args: list) -> stockOrder:
             orderObj.set_brokers(DAY1_BROKERS)
         elif args[1] == "most":
             orderObj.set_brokers(
-                list(filter(lambda x: x != "vanguard", SUPPORTED_BROKERS))
+                list(filter(lambda x: x != "vanguard", SUPPORTED_BROKonERS))
             )
         elif args[1] == "fast":
             orderObj.set_brokers(DAY1_BROKERS + ["robinhood"])
@@ -364,10 +364,13 @@ if __name__ == "__main__":
             await channel.send("Discord bot is started...")
 
         # Process the message only if it's from the specified channel
+        # Bypass process_commands to allow bot messages
         @bot.event
         async def on_message(message):
             if message.channel.id == DISCORD_CHANNEL:
-                await bot.process_commands(message)
+                ctx = await bot.get_context(message)
+                # the type of the invocation context's bot attribute will be correct
+                await bot.invoke(ctx)  # type: ignore
 
         # Bot ping-pong
         @bot.command(name="ping")

--- a/autoRSA.py
+++ b/autoRSA.py
@@ -234,7 +234,7 @@ def argParser(args: list) -> stockOrder:
             orderObj.set_brokers(DAY1_BROKERS)
         elif args[1] == "most":
             orderObj.set_brokers(
-                list(filter(lambda x: x != "vanguard", SUPPORTED_BROKonERS))
+                list(filter(lambda x: x != "vanguard", SUPPORTED_BROKERS))
             )
         elif args[1] == "fast":
             orderObj.set_brokers(DAY1_BROKERS + ["robinhood"])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,29 +2,10 @@ services:
     auto-rsa:
         container_name: auto-rsa
         image: docker.io/nelsondane/auto-rsa:latest # or change to other branch you want to use
-        # build: . # uncomment this line if you want to build the image locally with "docker compose up -d --build"
+        build: . # uncomment this line if you want to build the image locally with "docker compose up -d --build"
         restart: unless-stopped
         env_file:
             - .env
         tty: true
         volumes:
             - ./creds:/app/creds
-
-    watchtower:
-        # Auto update the auto-rsa container every hour
-        # For more info see: https://containrrr.dev/watchtower/arguments/
-        image: containrrr/watchtower
-        container_name: watchtower
-        hostname: auto-rsa
-        environment:
-            - WATCHTOWER_CLEANUP=true
-            - WATCHTOWER_INCLUDE_STOPPED=true
-            - WATCHTOWER_POLL_INTERVAL=3600
-            # For more info on notifications see: https://containrrr.dev/watchtower/notifications/
-            # - WATCHTOWER_NOTIFICATIONS=shoutrrr
-            # - WATCHTOWER_NOTIFICATION_URL=discord://TOKEN@WEBHOOKID
-        command:
-            - auto-rsa
-        volumes:
-            - /var/run/docker.sock:/var/run/docker.sock
-        restart: unless-stopped

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ python-dotenv==1.0.1
 requests==2.32.3
 # robin-stocks==3.3.1
 # https://github.com/jmfernandes/robin_stocks/pull/538
--e git+https://github.com/jmfernandes/robin_stocks.git@0d4574fb11ba4f1ff0acc8046174924bfd7ec532#egg=robin_stocks
+-e git+https://github.com/jmfernandes/robin_stocks.git@2018e55602ef92b7182186354d1be9517b7a16e8#egg=robin_stocks
 schwab-api==0.4.3
 selenium-stealth==1.0.6
 setuptools==76.0.0


### PR DESCRIPTION
Hello maintainers!

I'd like to propose this small change that enables the bot to process messages from other bots. This is the change [suggested by the discord.py maintainer](https://github.com/Rapptz/discord.py/issues/6579#issuecomment-808598640r.

The motivation for this is that there are websites that publish upcoming reverse stock splits. It would be feasible to have a bot post buy / sell commands on a Discord channel, and have auto-rsa perform the action.