### PR TITLE
Bypass process_commands to allow bot messages

### DIFF
--- a/autoRSA.py
+++ b/autoRSA.py
@@ -364,10 +364,13 @@ if __name__ == "__main__":
             await channel.send("Discord bot is started...")
 
         # Process the message only if it's from the specified channel
+        # Bypass process_commands to allow bot messages
         @bot.event
         async def on_message(message):
             if message.channel.id == DISCORD_CHANNEL:
-                await bot.process_commands(message)
+                ctx = await bot.get_context(message)
+                # the type of the invocation context's bot attribute will be correct
+                await bot.invoke(ctx)  # type: ignore
 
         # Bot ping-pong
         @bot.command(name="ping")

--- a/autoRSA.py
+++ b/autoRSA.py
@@ -367,7 +367,7 @@ if __name__ == "__main__":
         # Bypass process_commands to allow bot messages
         @bot.event
         async def on_message(message):
-            if message.channel.id == DISCORD_CHANNEL:
+            if message.channel.id == DISCORD_CHANNEL and message.author != bot.user:
                 ctx = await bot.get_context(message)
                 # the type of the invocation context's bot attribute will be correct
                 await bot.invoke(ctx)  # type: ignore


### PR DESCRIPTION
Hello maintainers!

I'd like to propose this small change that enables the bot to process messages from other bots. This is the change [suggested by the discord.py maintainer](https://github.com/Rapptz/discord.py/issues/6579#issuecomment-808598640r.

The motivation for this is that there are websites that publish upcoming reverse stock splits. It would be feasible to have a bot post buy / sell commands on a Discord channel, and have auto-rsa perform the action.