### PR TITLE
fix schwab update playwright

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,14 +9,14 @@ fidelity-api==0.0.12
 firstrade==0.0.33
 GitPython==3.1.44
 nodriver==0.45.2
-# playwright stealth from pypi seems abandoned
--e git+https://github.com/MaxxRK/playwright_stealth.git@f87d7c3d67134ad6def356dce6545c2f42662dfb#egg=playwright_stealth
+-e git+https://github.com/MaxxRK/playwright_stealth@64856026a91e85f7639c17ddc9cad42496233da9#egg=playwright_stealth
 public-invest-api==1.3.3
 pyotp==2.9.0
 python-dotenv==1.1.0
 requests==2.32.3
 robin-stocks==3.4.0
-schwab-api==0.4.3
+# schwab-api==0.4.3
+-e git+https://github.com/yanowitz/schwab-api.git@367ef565c35bf5c96b6d456c46c18ce05603d87a#egg=schwab-api
 selenium-stealth==1.0.6
 setuptools==80.3.1
 tastytrade==9.11


### PR DESCRIPTION
Schwab fix that works included until maintainer comes out with new package.

Update playwright to 1.52.0 to see if it helps with some reported user issues.  It still works with playwright stealth.